### PR TITLE
Add unit tests for secrets.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 
 // createActualSecretManagerClient conforms to the secrets.newClientFunc type.
 // It provides the actual implementation for creating a Secret Manager client.
-func createActualSecretManagerClient(ctx context.Context) (secrets.secretManagerClient, error) {
+func createActualSecretManagerClient(ctx context.Context) (secrets.SecretManagerClient, error) {
 	// secretmanager.NewClient returns *secretmanager.Client, which implements secrets.secretManagerClient
 	return secretmanager.NewClient(ctx)
 }

--- a/main.go
+++ b/main.go
@@ -12,9 +12,17 @@ import (
 	"cloud.google.com/go/firestore"
 	"github.com/google/uuid"
 	"disappr.io/crypto"
-	"disappr.io/secrets"
+	"disappr.io/secrets" // Will use secrets.secretManagerClient and secrets.newClientFunc
 	"disappr.io/auth"
+	secretmanager "cloud.google.com/go/secretmanager/apiv1" // Added for the actual client
 )
+
+// createActualSecretManagerClient conforms to the secrets.newClientFunc type.
+// It provides the actual implementation for creating a Secret Manager client.
+func createActualSecretManagerClient(ctx context.Context) (secrets.secretManagerClient, error) {
+	// secretmanager.NewClient returns *secretmanager.Client, which implements secrets.secretManagerClient
+	return secretmanager.NewClient(ctx)
+}
 
 type Paste struct {
 	ID             string    `json:"id"`
@@ -75,8 +83,9 @@ func createPasteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	key, err := secrets.GetEncryptionKey(r.Context())
+	key, err := secrets.GetEncryptionKey(r.Context(), createActualSecretManagerClient)
 	if err != nil {
+		log.Printf("Error getting encryption key: %v", err) // Log the actual error
 		http.Error(w, "Failed to load encryption key", http.StatusInternalServerError)
 		return
 	}
@@ -136,8 +145,9 @@ func viewPasteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	key, err := secrets.GetEncryptionKey(r.Context())
+	key, err := secrets.GetEncryptionKey(r.Context(), createActualSecretManagerClient)
 	if err != nil {
+		log.Printf("Error getting encryption key: %v", err) // Log the actual error
 		http.Error(w, "Failed to load encryption key", http.StatusInternalServerError)
 		return
 	}

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -6,23 +6,20 @@ import (
 	"fmt"
 	"os"
 
-	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"github.com/googleapis/gax-go/v2"
-	// Ensure option is imported if secretmanager.NewClient has options in its signature
-	// "google.golang.org/api/option"
 )
 
 // secretManagerClient defines the interface for the Secret Manager client.
 // This allows for mocking in tests.
-type secretManagerClient interface {
+type SecretManagerClient interface {
 	AccessSecretVersion(context.Context, *secretmanagerpb.AccessSecretVersionRequest, ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error)
 	Close() error
 }
 
 // newClientFunc defines a function type for creating a new secretManagerClient.
 // This is used to allow mocking of client creation.
-type newClientFunc func(ctx context.Context) (secretManagerClient, error)
+type newClientFunc func(ctx context.Context) (SecretManagerClient, error)
 
 func GetEncryptionKey(ctx context.Context, ncf newClientFunc) ([]byte, error) {
 	projectID := os.Getenv("GCP_PROJECT")

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -8,15 +8,32 @@ import (
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/googleapis/gax-go/v2"
+	// Ensure option is imported if secretmanager.NewClient has options in its signature
+	// "google.golang.org/api/option"
 )
 
-func GetEncryptionKey(ctx context.Context) ([]byte, error) {
+// secretManagerClient defines the interface for the Secret Manager client.
+// This allows for mocking in tests.
+type secretManagerClient interface {
+	AccessSecretVersion(context.Context, *secretmanagerpb.AccessSecretVersionRequest, ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error)
+	Close() error
+}
+
+// newClientFunc defines a function type for creating a new secretManagerClient.
+// This is used to allow mocking of client creation.
+type newClientFunc func(ctx context.Context) (secretManagerClient, error)
+
+func GetEncryptionKey(ctx context.Context, ncf newClientFunc) ([]byte, error) {
 	projectID := os.Getenv("GCP_PROJECT")
+	if projectID == "" {
+		return nil, fmt.Errorf("GCP_PROJECT environment variable not set")
+	}
 	name := fmt.Sprintf("projects/%s/secrets/disappr-aes-key/versions/latest", projectID)
 
-	client, err := secretmanager.NewClient(ctx)
+	client, err := ncf(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create secret manager client: %w", err)
 	}
 	defer client.Close()
 
@@ -26,12 +43,12 @@ func GetEncryptionKey(ctx context.Context) ([]byte, error) {
 
 	result, err := client.AccessSecretVersion(ctx, accessReq)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to access secret version: %w", err)
 	}
 
 	key, err := base64.StdEncoding.DecodeString(string(result.Payload.Data))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to decode secret data: %w", err)
 	}
 
 	return key, nil

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -1,0 +1,157 @@
+package secrets
+
+import (
+	"context"
+	"encoding/base64"
+	"errors" // Added for the new test case
+	"testing"
+
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/googleapis/gax-go/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockSecretManagerClient is a mock implementation of the secretManagerClient interface.
+type mockSecretManagerClient struct {
+	accessSecretVersionFunc func(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error)
+	closeFunc               func() error
+}
+
+func (m *mockSecretManagerClient) AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+	if m.accessSecretVersionFunc != nil {
+		return m.accessSecretVersionFunc(ctx, req, opts...)
+	}
+	// Default behavior: Return an empty response and no error, or an error if appropriate
+	return &secretmanagerpb.AccessSecretVersionResponse{}, nil
+}
+
+func (m *mockSecretManagerClient) Close() error {
+	if m.closeFunc != nil {
+		return m.closeFunc()
+	}
+	return nil // Default behavior if not set
+}
+
+func TestGetEncryptionKey_Success(t *testing.T) {
+	// Define the expected key (decoded) and the base64 encoded version
+	expectedKey := []byte("this-is-a-test-key-32-bytes-long") // 32 bytes
+	encodedKey := base64.StdEncoding.EncodeToString(expectedKey)
+
+	// Create a mock SecretManager client instance
+	mockClientInstance := &mockSecretManagerClient{
+		accessSecretVersionFunc: func(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+			return &secretmanagerpb.AccessSecretVersionResponse{
+				Payload: &secretmanagerpb.SecretPayload{
+					Data: []byte(encodedKey),
+				},
+			}, nil
+		},
+		closeFunc: func() error {
+			return nil
+		},
+	}
+
+	// Define the newClientFunc to return the mock client instance
+	mockNCF := func(ctx context.Context) (secretManagerClient, error) {
+		return mockClientInstance, nil
+	}
+
+	// Call GetEncryptionKey with the mock newClientFunc
+	ctx := context.Background()
+	// Set GCP_PROJECT for the test environment
+	t.Setenv("GCP_PROJECT", "test-project")
+	key, err := GetEncryptionKey(ctx, mockNCF)
+
+	// Assertions
+	assert.NoError(t, err, "GetEncryptionKey should not return an error")
+	assert.Equal(t, expectedKey, key, "Returned key does not match expected key")
+}
+
+func TestGetEncryptionKey_ClientError(t *testing.T) {
+	expectedErrorMsg := "mock NewClient error"
+
+	// Define a newClientFunc that returns an error
+	mockNCF := func(ctx context.Context) (secretManagerClient, error) {
+		return nil, errors.New(expectedErrorMsg)
+	}
+
+	// Call GetEncryptionKey with the mock newClientFunc
+	ctx := context.Background()
+	// Set GCP_PROJECT for the test environment, though it won't be used if client creation fails
+	t.Setenv("GCP_PROJECT", "test-project")
+	key, err := GetEncryptionKey(ctx, mockNCF)
+
+	// Assertions
+	assert.Error(t, err, "GetEncryptionKey should return an error")
+	assert.Nil(t, key, "Returned key should be nil on client error")
+	assert.Contains(t, err.Error(), "failed to create secret manager client", "Error message should indicate client creation failure")
+	assert.Contains(t, err.Error(), expectedErrorMsg, "Error message should contain the original error")
+}
+
+func TestGetEncryptionKey_AccessSecretVersionError(t *testing.T) {
+	expectedErrorMsg := "mock AccessSecretVersion error"
+
+	// Create a mock SecretManager client instance
+	mockClientInstance := &mockSecretManagerClient{
+		accessSecretVersionFunc: func(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+			// Return the predefined error for AccessSecretVersion
+			return nil, errors.New(expectedErrorMsg)
+		},
+		closeFunc: func() error {
+			return nil
+		},
+	}
+
+	// Define the newClientFunc to return the mock client instance (simulating successful client creation)
+	mockNCF := func(ctx context.Context) (secretManagerClient, error) {
+		return mockClientInstance, nil
+	}
+
+	// Call GetEncryptionKey with the mock newClientFunc
+	ctx := context.Background()
+	// Set GCP_PROJECT for the test environment
+	t.Setenv("GCP_PROJECT", "test-project")
+	key, err := GetEncryptionKey(ctx, mockNCF)
+
+	// Assertions
+	assert.Error(t, err, "GetEncryptionKey should return an error due to AccessSecretVersion failure")
+	assert.Nil(t, key, "Returned key should be nil on AccessSecretVersion error")
+	assert.Contains(t, err.Error(), "failed to access secret version", "Error message should indicate AccessSecretVersion failure")
+	assert.Contains(t, err.Error(), expectedErrorMsg, "Error message should contain the original AccessSecretVersion error")
+}
+
+func TestGetEncryptionKey_DecodeError(t *testing.T) {
+	invalidBase64String := "this-is-not-base64"
+
+	// Create a mock SecretManager client instance
+	mockClientInstance := &mockSecretManagerClient{
+		accessSecretVersionFunc: func(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+			return &secretmanagerpb.AccessSecretVersionResponse{
+				Payload: &secretmanagerpb.SecretPayload{
+					Data: []byte(invalidBase64String),
+				},
+			}, nil
+		},
+		closeFunc: func() error {
+			return nil
+		},
+	}
+
+	// Define the newClientFunc to return the mock client instance
+	mockNCF := func(ctx context.Context) (secretManagerClient, error) {
+		return mockClientInstance, nil
+	}
+
+	// Call GetEncryptionKey with the mock newClientFunc
+	ctx := context.Background()
+	// Set GCP_PROJECT for the test environment
+	t.Setenv("GCP_PROJECT", "test-project")
+	key, err := GetEncryptionKey(ctx, mockNCF)
+
+	// Assertions
+	assert.Error(t, err, "GetEncryptionKey should return an error due to base64 decoding failure")
+	assert.Nil(t, key, "Returned key should be nil on decoding error")
+	assert.Contains(t, err.Error(), "failed to decode secret data", "Error message should indicate decoding failure")
+	// Check for the specific Go base64 error text
+	assert.Contains(t, err.Error(), "illegal base64 data", "Error message should contain specific base64 error")
+}

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -3,7 +3,7 @@ package secrets
 import (
 	"context"
 	"encoding/base64"
-	"errors" // Added for the new test case
+	"errors"
 	"testing"
 
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
@@ -52,7 +52,7 @@ func TestGetEncryptionKey_Success(t *testing.T) {
 	}
 
 	// Define the newClientFunc to return the mock client instance
-	mockNCF := func(ctx context.Context) (secretManagerClient, error) {
+	mockNCF := func(ctx context.Context) (SecretManagerClient, error) {
 		return mockClientInstance, nil
 	}
 
@@ -71,7 +71,7 @@ func TestGetEncryptionKey_ClientError(t *testing.T) {
 	expectedErrorMsg := "mock NewClient error"
 
 	// Define a newClientFunc that returns an error
-	mockNCF := func(ctx context.Context) (secretManagerClient, error) {
+	mockNCF := func(ctx context.Context) (SecretManagerClient, error) {
 		return nil, errors.New(expectedErrorMsg)
 	}
 
@@ -103,7 +103,7 @@ func TestGetEncryptionKey_AccessSecretVersionError(t *testing.T) {
 	}
 
 	// Define the newClientFunc to return the mock client instance (simulating successful client creation)
-	mockNCF := func(ctx context.Context) (secretManagerClient, error) {
+	mockNCF := func(ctx context.Context) (SecretManagerClient, error) {
 		return mockClientInstance, nil
 	}
 
@@ -138,7 +138,7 @@ func TestGetEncryptionKey_DecodeError(t *testing.T) {
 	}
 
 	// Define the newClientFunc to return the mock client instance
-	mockNCF := func(ctx context.Context) (secretManagerClient, error) {
+	mockNCF := func(ctx context.Context) (SecretManagerClient, error) {
 		return mockClientInstance, nil
 	}
 


### PR DESCRIPTION
This commit adds unit tests for the GetEncryptionKey function in secrets.go. The tests cover the following cases:
- Successful retrieval of the encryption key.
- Error when the Secret Manager client fails to initialize.
- Error when accessing the secret version fails.
- Error when decoding the secret fails.

The GetEncryptionKey function was also modified to accept a newClientFunc parameter to allow mocking of the Secret Manager client for testing purposes.